### PR TITLE
Key reactions by ids

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -39,8 +39,8 @@ service cloud.firestore {
     }
     match /sessions/{sessionId}/reactions/{reactionId} {
     	allow create: if
-      	request.resource.data.keys().hasAll(['reaction', 'ttl'])
-      	&& request.resource.data.keys().hasOnly(['reaction', 'ttl']);
+      	request.resource.data.keys().hasAll(['reaction', 'ttl', 'created'])
+      	&& request.resource.data.keys().hasOnly(['reaction', 'ttl', 'created']);
       allow read: if true;
     }
   }

--- a/src/components/broadcast/use-broadcast-channel.ts
+++ b/src/components/broadcast/use-broadcast-channel.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import {nanoid} from 'nanoid';
 import {type Handler, type Payload} from './use-channel-handlers';
 
 export default function useBroadcastChannel({
@@ -18,6 +19,19 @@ export default function useBroadcastChannel({
     const channelMessageHandler = (event: MessageEvent) => {
       console.log('incoming bc', channelId, event);
       if (onIncoming) {
+        const incomingPayload = event.data as Payload;
+
+        if (incomingPayload.id === 'reactions') {
+          onIncoming({
+            id: 'reactions',
+            reactions: incomingPayload.reactions.map(([, reaction]) => [
+              nanoid(),
+              reaction,
+            ]),
+          });
+          return;
+        }
+
         onIncoming(event.data as Payload);
       }
     };

--- a/src/components/broadcast/use-channel-handlers.ts
+++ b/src/components/broadcast/use-channel-handlers.ts
@@ -8,8 +8,8 @@ export type Payload =
       icon?: never;
     }
   | {
-      id: 'reaction';
-      reaction: ReactionEntry;
+      id: 'reactions';
+      reactions: ReactionEntry[];
     };
 export type Handler = (payload: Payload) => void;
 

--- a/src/components/confetti/Confetti.tsx
+++ b/src/components/confetti/Confetti.tsx
@@ -1,36 +1,81 @@
+import {useEffect, useRef, useState} from 'react';
 import ReactCanvasConfetti from 'react-canvas-confetti';
+import {type ConfettiReactionEntry} from '../reactions/reaction';
 
-export default function Confetti({fire, reset}: {fire: any; reset?: any}) {
+function confettiProps(): confetti.Options {
+  return {
+    angle: 90,
+    colors: [
+      '#26ccff',
+      '#a25afd',
+      '#ff5e7e',
+      '#88ff5a',
+      '#fcff42',
+      '#ffa62d',
+      '#ff36ff',
+    ],
+    decay: 0.8,
+    drift: 0,
+    gravity: 1,
+    origin: {
+      x: Math.random(),
+      y: Math.random(),
+    },
+    particleCount: 500,
+    scalar: 1,
+    shapes: ['circle', 'square', 'star'],
+    spread: 360,
+    startVelocity: 45,
+    ticks: 600,
+  };
+}
+
+export default function Confetti({
+  confettiReactions,
+  clear,
+  fire,
+}: {
+  confettiReactions: ConfettiReactionEntry[];
+  clear?: any;
+  fire?: any;
+}) {
+  const [doneReactions, setDoneReactions] = useState<string[]>([]);
+  const confettiRef = useRef<confetti.CreateTypes>();
+  useEffect(() => {
+    for (const [id, confettiReaction] of confettiReactions) {
+      if (doneReactions.includes(id)) {
+        continue;
+      }
+
+      if (confettiReaction === 'confetti') {
+        void confettiRef.current?.(confettiProps());
+      }
+
+      setDoneReactions((currentDoneReactions) => [...currentDoneReactions, id]);
+    }
+  }, [confettiReactions, doneReactions]);
+
+  useEffect(() => {
+    if (clear) {
+      console.log('clearing');
+      confettiRef.current?.reset();
+    }
+  }, [clear]);
+
+  useEffect(() => {
+    if (fire) {
+      void confettiRef.current?.(confettiProps());
+    }
+  }, [fire]);
+
   return (
     <ReactCanvasConfetti
       resize
       useWorker
-      fire={fire} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-      reset={reset} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-      angle={90}
-      className="position-fixed top-0 left-0 w-screen h-screen pointer-events-none"
-      colors={[
-        '#26ccff',
-        '#a25afd',
-        '#ff5e7e',
-        '#88ff5a',
-        '#fcff42',
-        '#ffa62d',
-        '#ff36ff',
-      ]}
-      decay={0.8}
-      drift={0}
-      gravity={1}
-      origin={{
-        x: Math.random(),
-        y: Math.random(),
+      refConfetti={(confetti) => {
+        confettiRef.current = confetti ?? undefined;
       }}
-      particleCount={500}
-      scalar={1}
-      shapes={['circle', 'square', 'star']}
-      spread={360}
-      startVelocity={45}
-      ticks={600}
+      className="position-fixed top-0 left-0 w-screen h-screen pointer-events-none"
     />
   );
 }

--- a/src/components/confetti/use-confetti.ts
+++ b/src/components/confetti/use-confetti.ts
@@ -1,8 +1,5 @@
 import {useCallback, useMemo} from 'react';
-import {
-  type HandlerEntries,
-  type Handler,
-} from '../broadcast/use-channel-handlers';
+import {type Handler, type Payload} from '../broadcast/use-channel-handlers';
 
 export default function useConfetti({
   postMessage,
@@ -15,30 +12,31 @@ export default function useConfetti({
 }): {
   postConfetti: () => void;
   postConfettiReset: () => void;
-  handlers: HandlerEntries;
+  handlers: Handler[];
 } {
   const postConfetti = useCallback(() => {
-    postMessage?.({id: 'confetti'});
+    postMessage?.({id: 'reaction', reaction: ['', 'confetti']});
   }, [postMessage]);
 
   const postConfettiReset = useCallback(() => {
-    postMessage?.({id: 'confetti reset'});
+    postMessage?.({id: 'reaction', reaction: ['', 'confetti clear']});
   }, [postMessage]);
 
-  const handlers = useMemo<HandlerEntries>(
+  const handlers = useMemo<Handler[]>(
     () => [
-      [
-        'confetti',
-        () => {
+      (payload: Payload) => {
+        if (payload.id === 'reaction' && payload.reaction[1] === 'confetti') {
           onConfetti?.({});
-        },
-      ],
-      [
-        'confetti reset',
-        () => {
+        }
+      },
+      (payload: Payload) => {
+        if (
+          payload.id === 'reaction' &&
+          payload.reaction[1] === 'confetti clear'
+        ) {
           onReset?.({});
-        },
-      ],
+        }
+      },
     ],
     [onConfetti, onReset],
   );

--- a/src/components/confetti/use-confetti.ts
+++ b/src/components/confetti/use-confetti.ts
@@ -1,45 +1,33 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import {type Handler, type Payload} from '../broadcast/use-channel-handlers';
+import {type ConfettiReactionEntry} from '../reactions/reaction';
 
-export default function useConfetti({
-  postMessage,
-  onConfetti,
-  onReset,
-}: {
-  postMessage?: Handler;
-  onConfetti?: (data: any) => void;
-  onReset?: (data: any) => void;
-}): {
+export default function useConfetti({postMessage}: {postMessage?: Handler}): {
   postConfetti: () => void;
-  postConfettiReset: () => void;
   handlers: Handler[];
+  confettiReactions: ConfettiReactionEntry[];
 } {
   const postConfetti = useCallback(() => {
-    postMessage?.({id: 'reaction', reaction: ['', 'confetti']});
+    postMessage?.({id: 'reactions', reactions: [['', 'confetti']]});
   }, [postMessage]);
 
-  const postConfettiReset = useCallback(() => {
-    postMessage?.({id: 'reaction', reaction: ['', 'confetti clear']});
-  }, [postMessage]);
+  const [confettiReactions, setConfettiReactions] = useState<
+    ConfettiReactionEntry[]
+  >([]);
 
   const handlers = useMemo<Handler[]>(
     () => [
       (payload: Payload) => {
-        if (payload.id === 'reaction' && payload.reaction[1] === 'confetti') {
-          onConfetti?.({});
-        }
-      },
-      (payload: Payload) => {
-        if (
-          payload.id === 'reaction' &&
-          payload.reaction[1] === 'confetti clear'
-        ) {
-          onReset?.({});
+        if (payload.id === 'reactions') {
+          const confettiReactions = payload.reactions.filter(
+            ([, reaction]) => reaction === 'confetti',
+          ) as ConfettiReactionEntry[];
+          setConfettiReactions(confettiReactions);
         }
       },
     ],
-    [onConfetti, onReset],
+    [],
   );
 
-  return {postConfetti, postConfettiReset, handlers};
+  return {postConfetti, handlers, confettiReactions};
 }

--- a/src/components/reactions/ReactionControls.tsx
+++ b/src/components/reactions/ReactionControls.tsx
@@ -1,11 +1,14 @@
+import clsx from 'clsx';
 import Button from '../toolbar/Button';
+import {type IconReaction} from './reaction';
+import reactionsIconMap from './reaction-icons-map';
 
 export default function ReactionControls({
   handleConfetti,
   handleReaction,
 }: {
   handleConfetti: () => void;
-  handleReaction: (icon: string) => void;
+  handleReaction: (reaction: IconReaction) => void;
 }) {
   return (
     <div className="max-w-lg mx-auto grid grid-cols-[4rem_4rem_4rem_4rem] gap-4 grid-rows-[4rem_4rem]">
@@ -19,46 +22,19 @@ export default function ReactionControls({
           handleConfetti();
         }}
       />
-      <Button
-        border
-        label="love"
-        title="React with love"
-        icon="i-fluent-emoji-flat-red-heart h-8 w-8"
-        className="relative"
-        onClick={() => {
-          handleReaction('i-fluent-emoji-flat-red-heart');
-        }}
-      />
-      <Button
-        border
-        label="smile"
-        title="React with a smile"
-        icon="i-fluent-emoji-flat-smiling-face h-8 w-8"
-        className="relative"
-        onClick={() => {
-          handleReaction('i-fluent-emoji-flat-smiling-face');
-        }}
-      />
-      <Button
-        border
-        label="clap"
-        title="React with clapping hands"
-        icon="i-fluent-emoji-flat-clapping-hands h-8 w-8"
-        className="relative"
-        onClick={() => {
-          handleReaction('i-fluent-emoji-flat-clapping-hands');
-        }}
-      />
-      <Button
-        border
-        label="explode"
-        title="React with a exploding brain"
-        icon="i-fluent-emoji-flat-exploding-head h-8 w-8"
-        className="relative"
-        onClick={() => {
-          handleReaction('i-fluent-emoji-flat-exploding-head');
-        }}
-      />
+      {Array.from(reactionsIconMap.entries()).map(([label, {icon, title}]) => (
+        <Button
+          key={label}
+          border
+          label={label}
+          title={title}
+          icon={clsx(icon, 'h-8 w-8')}
+          className="relative"
+          onClick={() => {
+            handleReaction(label);
+          }}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/reactions/Reactions.tsx
+++ b/src/components/reactions/Reactions.tsx
@@ -1,10 +1,6 @@
 import clsx from 'clsx';
 import {useEffect, useMemo, useRef} from 'react';
-import {
-  type IconReaction,
-  type IconReactionEntry,
-  type IconReactionMap,
-} from './reaction';
+import {type IconReaction, type IconReactionMap} from './reaction';
 import reactionsIconMap from './reaction-icons-map';
 
 // This file is inspired from these 2 articles:
@@ -74,20 +70,22 @@ export default function Reactions({
   removeReaction,
 }: {
   reactions: IconReactionMap;
-  removeReaction: (reaction: IconReactionEntry) => void;
+  removeReaction: (id: string) => void;
 }) {
   return (
     <div className="fixed top-0 left-0 h-screen w-screen pointer-events-none">
       <div className="relative left-[calc(3rem_+_20px)] h-full w-[calc(calc(100vw_-_6rem)_-_40px)] max-h-screen">
-        {Array.from(reactions.entries()).map(([id, reaction]) => (
-          <Reaction
-            key={id}
-            reaction={reaction}
-            onReactionDone={() => {
-              removeReaction([id, reaction]);
-            }}
-          />
-        ))}
+        {Array.from(reactions.entries())
+          .filter(([, renderedReaction]) => !renderedReaction.done)
+          .map(([id, renderedReaction]) => (
+            <Reaction
+              key={id}
+              reaction={renderedReaction.reaction}
+              onReactionDone={() => {
+                removeReaction(id);
+              }}
+            />
+          ))}
       </div>
     </div>
   );

--- a/src/components/reactions/Reactions.tsx
+++ b/src/components/reactions/Reactions.tsx
@@ -1,24 +1,22 @@
 import clsx from 'clsx';
 import {useEffect, useMemo, useRef} from 'react';
-import {type Reaction as ReactionType} from './reaction';
+import {
+  type IconReaction,
+  type IconReactionEntry,
+  type IconReactionMap,
+} from './reaction';
+import reactionsIconMap from './reaction-icons-map';
 
 // This file is inspired from these 2 articles:
 // https://eng.butter.us/awesome-floating-emoji-reactions-using-framer-motion-styled-components-and-lottie-36b9f479a9f9
 // https://www.daily.co/blog/add-flying-emoji-reactions-to-a-custom-daily-video-call/
 
-const reactionLabels: Record<string, string> = {
-  'i-fluent-emoji-flat-red-heart': 'love',
-  'i-fluent-emoji-flat-smiling-face': 'smile',
-  'i-fluent-emoji-flat-clapping-hands': 'applause',
-  'i-fluent-emoji-flat-exploding-head': 'mind blown',
-};
-
 function Reaction({
   onReactionDone,
-  icon = 'i-fluent-emoji-flat-red-heart',
+  reaction,
 }: {
   onReactionDone: () => void;
-  icon?: string;
+  reaction: IconReaction;
 }) {
   // Keep a ref to the reaction div so we can add the random style vars
   const reactionRef = useRef<HTMLDivElement>(null);
@@ -60,12 +58,12 @@ function Reaction({
   return (
     <div
       ref={reactionRef}
-      aria-label={reactionLabels[icon] ?? 'unknown'}
+      aria-label={reaction}
       role="figure"
       style={{left: `var(--reaction-x-offset)`}}
       className={clsx(
         'animate-emoji absolute bottom--100px bottom--12 leading-none text-size-12 overflow-visible',
-        icon,
+        reactionsIconMap.get(reaction)?.icon,
       )}
     />
   );
@@ -75,18 +73,18 @@ export default function Reactions({
   reactions,
   removeReaction,
 }: {
-  reactions: ReactionType[];
-  removeReaction: (reaction: ReactionType) => void;
+  reactions: IconReactionMap;
+  removeReaction: (reaction: IconReactionEntry) => void;
 }) {
   return (
     <div className="fixed top-0 left-0 h-screen w-screen pointer-events-none">
       <div className="relative left-[calc(3rem_+_20px)] h-full w-[calc(calc(100vw_-_6rem)_-_40px)] max-h-screen">
-        {reactions.map((reaction) => (
+        {Array.from(reactions.entries()).map(([id, reaction]) => (
           <Reaction
-            key={reaction.id}
-            icon={reaction.icon}
+            key={id}
+            reaction={reaction}
             onReactionDone={() => {
-              removeReaction(reaction);
+              removeReaction([id, reaction]);
             }}
           />
         ))}

--- a/src/components/reactions/reaction-icons-map.ts
+++ b/src/components/reactions/reaction-icons-map.ts
@@ -1,0 +1,29 @@
+// @unocss-include
+import {type IconReaction} from './reaction';
+
+const reactionsIconMap = new Map<IconReaction, {icon: string; title: string}>([
+  ['love', {icon: 'i-fluent-emoji-flat-red-heart', title: 'React with love'}],
+  [
+    'smile',
+    {
+      icon: 'i-fluent-emoji-flat-smiling-face',
+      title: 'React with a smile',
+    },
+  ],
+  [
+    'applause',
+    {
+      icon: 'i-fluent-emoji-flat-clapping-hands',
+      title: 'React with applause',
+    },
+  ],
+  [
+    'explode',
+    {
+      icon: 'i-fluent-emoji-flat-exploding-head',
+      title: 'React with a exploding brain',
+    },
+  ],
+]);
+
+export default reactionsIconMap;

--- a/src/components/reactions/reaction.d.ts
+++ b/src/components/reactions/reaction.d.ts
@@ -8,7 +8,6 @@ export type ReactionEntry = [string, ReactionType];
 export type IconReactionEntry = [string, RenderedReaction];
 export type IconReactionMap = Map<string, RenderedReaction>;
 export type ConfettiReactionEntry = [string, ConfettiReaction];
-export type ClearReactionEntry = [string, ClearReactionEntry];
 
 type CommonReactionData = {
   reaction: ReactionType;

--- a/src/components/reactions/reaction.d.ts
+++ b/src/components/reactions/reaction.d.ts
@@ -1,9 +1,29 @@
-export type Reaction = {
-  id: number;
-  icon: string;
-};
+import {type Timestamp, type FieldValue} from 'firebase/firestore';
 
-export type ReactionData = {
-  reaction: string;
+export type IconReaction = 'love' | 'smile' | 'applause' | 'explode';
+
+export type ConfettiReaction = 'confetti' | 'confetti clear';
+
+export type ReactionType = IconReaction | ConfettiReaction;
+
+// Export type ReactionRecord = Record<string, ReactionType>;
+export type ReactionMap = Map<string, ReactionType>;
+export type ReactionEntry = [string, ReactionType];
+export type IconReactionEntry = [string, IconReaction];
+export type IconReactionMap = Map<string, IconReaction>;
+export type ConfettiReactionEntry = [string, ConfettiReaction];
+
+type CommonReactionData = {
+  reaction: ReactionType;
   ttl: Date;
 };
+
+export type IncomingReactionData = CommonReactionData & {
+  created: Timestamp;
+};
+
+export type OutgoingReactionData = CommonReactionData & {
+  created: FieldValue;
+};
+
+export type ReactionData = IncomingReactionData | OutgoingReactionData;

--- a/src/components/reactions/reaction.d.ts
+++ b/src/components/reactions/reaction.d.ts
@@ -1,17 +1,11 @@
 import {type Timestamp, type FieldValue} from 'firebase/firestore';
 
 export type IconReaction = 'love' | 'smile' | 'applause' | 'explode';
-
 export type ConfettiReaction = 'confetti' | 'confetti clear';
-
 export type ReactionType = IconReaction | ConfettiReaction;
-
-// Export type ReactionRecord = Record<string, ReactionType>;
-export type ReactionMap = Map<string, ReactionType>;
 export type ReactionEntry = [string, ReactionType];
 export type IconReactionEntry = [string, IconReaction];
 export type IconReactionMap = Map<string, IconReaction>;
-export type ConfettiReactionEntry = [string, ConfettiReaction];
 
 type CommonReactionData = {
   reaction: ReactionType;

--- a/src/components/reactions/reaction.d.ts
+++ b/src/components/reactions/reaction.d.ts
@@ -1,15 +1,23 @@
 import {type Timestamp, type FieldValue} from 'firebase/firestore';
 
 export type IconReaction = 'love' | 'smile' | 'applause' | 'explode';
-export type ConfettiReaction = 'confetti' | 'confetti clear';
-export type ReactionType = IconReaction | ConfettiReaction;
+export type ConfettiReaction = 'confetti';
+export type ClearReaction = 'clear';
+export type ReactionType = IconReaction | ConfettiReaction | ClearReaction;
 export type ReactionEntry = [string, ReactionType];
-export type IconReactionEntry = [string, IconReaction];
-export type IconReactionMap = Map<string, IconReaction>;
+export type IconReactionEntry = [string, RenderedReaction];
+export type IconReactionMap = Map<string, RenderedReaction>;
+export type ConfettiReactionEntry = [string, ConfettiReaction];
+export type ClearReactionEntry = [string, ClearReactionEntry];
 
 type CommonReactionData = {
   reaction: ReactionType;
   ttl: Date;
+};
+
+type RenderedReaction = {
+  done?: boolean;
+  reaction: IconReaction;
 };
 
 export type IncomingReactionData = CommonReactionData & {

--- a/src/components/reactions/use-clear-reactions.ts
+++ b/src/components/reactions/use-clear-reactions.ts
@@ -1,0 +1,57 @@
+import {useCallback, useMemo, useState} from 'react';
+import {type Handler, type Payload} from '../broadcast/use-channel-handlers';
+
+export default function useClearReactions({
+  postMessage,
+  setClearConfetti,
+  setClearIcons,
+}: {
+  postMessage?: Handler;
+  setClearConfetti?: () => void;
+  setClearIcons?: () => void;
+}): {
+  clearReactions: () => void;
+  handlers: Handler[];
+} {
+  const [clears, setClears] = useState<string[]>([]);
+
+  const clearLocal = useCallback(() => {
+    setClearConfetti?.();
+    setClearIcons?.();
+  }, [setClearConfetti, setClearIcons]);
+
+  const clearReactions = useCallback(() => {
+    clearLocal?.();
+    postMessage?.({id: 'reactions', reactions: [['', 'clear']]});
+  }, [clearLocal, postMessage]);
+
+  const handlers = useMemo<Handler[]>(
+    () => [
+      (payload: Payload) => {
+        if (payload.id === 'reactions') {
+          const clearIds = payload.reactions
+            .filter(
+              ([id, reaction]) =>
+                reaction === 'clear' &&
+                (id.length === 0 || !clears.includes(id)),
+            )
+            .map(([id]) => id);
+
+          if (clearIds.length > 0) {
+            clearLocal();
+            setClears((currentClears) => [
+              ...currentClears,
+              ...clearIds.filter(Boolean),
+            ]);
+          }
+        }
+      },
+    ],
+    [clearLocal, clears],
+  );
+
+  return {
+    clearReactions,
+    handlers,
+  };
+}

--- a/src/components/reactions/use-reactions.ts
+++ b/src/components/reactions/use-reactions.ts
@@ -1,55 +1,59 @@
 import {useCallback, useState} from 'react';
 import {
-  type ReactionEntry,
   type IconReactionEntry,
   type IconReactionMap,
-  type IconReaction,
+  type RenderedReaction,
 } from './reaction';
 
 export default function useReactions(): {
-  removeReaction: (reaction: IconReactionEntry) => void;
-  addReaction: (reaction: IconReactionEntry) => void;
+  removeReaction: (id: string) => void;
+  addReactions: (reactions: IconReactionEntry[]) => void;
   reactions: IconReactionMap;
   clearReactions: () => void;
 } {
   const [reactions, setReactions] = useState<IconReactionMap>(
-    new Map<string, IconReaction>(),
+    new Map<string, RenderedReaction>(),
   );
 
   const removeReaction = useCallback(
-    ([id]: ReactionEntry) => {
+    (id: string) => {
       setReactions((currentReactions) => {
         const nextReactions = new Map(currentReactions);
-        nextReactions.delete(id);
+        nextReactions.set(id, {...nextReactions.get(id)!, done: true});
         return nextReactions;
       });
     },
     [setReactions],
   );
 
-  const addReaction = useCallback(
-    ([id, reaction]: IconReactionEntry) => {
-      setReactions((currentReactions) => {
-        // Don't add existing reactions
-        if (currentReactions.has(id)) {
-          return currentReactions;
-        }
-
-        const nextReactions = new Map(currentReactions);
-        nextReactions.set(id, reaction);
-        return nextReactions;
-      });
+  const addReactions = useCallback(
+    (reactions: IconReactionEntry[]) => {
+      setReactions(
+        (currentReactions) => new Map([...reactions, ...currentReactions]),
+      );
     },
     [setReactions],
   );
 
   const clearReactions = useCallback(() => {
-    setReactions(new Map<string, IconReaction>());
+    setReactions(
+      (currentReactions) =>
+        // Set all reactions to done
+        new Map(
+          Array.from(currentReactions).map(([id, reaction]) => [
+            id,
+            {
+              ...reaction,
+              done: true,
+            },
+          ]),
+        ),
+    );
   }, [setReactions]);
 
   return {
     removeReaction,
-    addReaction,
+    addReactions,
     reactions,
     clearReactions,
   };

--- a/src/components/reactions/use-reactions.ts
+++ b/src/components/reactions/use-reactions.ts
@@ -1,59 +1,56 @@
 import {useCallback, useState} from 'react';
-import {type Reaction} from './reaction';
+import {
+  type ReactionEntry,
+  type IconReactionEntry,
+  type IconReactionMap,
+  type IconReaction,
+} from './reaction';
 
 export default function useReactions(): {
-  removeReaction: (reaction: Reaction) => void;
-  addReaction: (icon: string) => void;
-  reactions: Reaction[];
+  removeReaction: (reaction: IconReactionEntry) => void;
+  addReaction: (reaction: IconReactionEntry) => void;
+  reactions: IconReactionMap;
   clearReactions: () => void;
 } {
-  const [reactions, setReactions] = useState<{
-    nextIndex: number;
-    currentReactions: Reaction[];
-  }>({
-    nextIndex: 0,
-    currentReactions: [],
-  });
+  const [reactions, setReactions] = useState<IconReactionMap>(
+    new Map<string, IconReaction>(),
+  );
 
   const removeReaction = useCallback(
-    (reaction: Reaction) => {
-      setReactions((currentReactions) => ({
-        ...currentReactions,
-        currentReactions: currentReactions.currentReactions.filter(
-          (existingReaction) => existingReaction.id !== reaction.id,
-        ),
-      }));
+    ([id]: ReactionEntry) => {
+      setReactions((currentReactions) => {
+        const nextReactions = new Map(currentReactions);
+        nextReactions.delete(id);
+        return nextReactions;
+      });
     },
     [setReactions],
   );
 
   const addReaction = useCallback(
-    (icon: string) => {
-      setReactions((currentReactions) => ({
-        nextIndex: currentReactions.nextIndex + 1,
-        currentReactions: [
-          ...currentReactions.currentReactions,
-          {
-            id: currentReactions.nextIndex,
-            icon,
-          },
-        ],
-      }));
+    ([id, reaction]: IconReactionEntry) => {
+      setReactions((currentReactions) => {
+        // Don't add existing reactions
+        if (currentReactions.has(id)) {
+          return currentReactions;
+        }
+
+        const nextReactions = new Map(currentReactions);
+        nextReactions.set(id, reaction);
+        return nextReactions;
+      });
     },
     [setReactions],
   );
 
   const clearReactions = useCallback(() => {
-    setReactions((currentReactions) => ({
-      ...currentReactions,
-      currentReactions: [],
-    }));
+    setReactions(new Map<string, IconReaction>());
   }, [setReactions]);
 
   return {
     removeReaction,
     addReaction,
-    reactions: reactions.currentReactions,
+    reactions,
     clearReactions,
   };
 }

--- a/src/components/reactions/use-remote-reactions.ts
+++ b/src/components/reactions/use-remote-reactions.ts
@@ -1,35 +1,38 @@
 import {useCallback, useMemo} from 'react';
-import {
-  type HandlerEntries,
-  type Handler,
-  type Payload,
-} from '../broadcast/use-channel-handlers';
+import {type Handler, type Payload} from '../broadcast/use-channel-handlers';
+import {type IconReaction, type IconReactionEntry} from './reaction';
+import reactionsIconMap from './reaction-icons-map';
+
+const reactionTypes = new Set(Array.from(reactionsIconMap.keys()));
 
 export default function useRemoteReactions({
   postMessage,
   onReaction,
 }: {
   postMessage?: Handler;
-  onReaction?: (icon: string) => void;
+  onReaction?: (reaction: IconReactionEntry) => void;
 }): {
-  postReaction: (icon: string) => void;
-  handlers: HandlerEntries;
+  postReaction: (reaction: IconReaction) => void;
+  handlers: Handler[];
 } {
   const postReaction = useCallback(
-    (icon: string) => {
-      postMessage?.({id: 'reaction', icon});
+    (reaction: IconReaction) => {
+      postMessage?.({id: 'reaction', reaction: ['', reaction]});
     },
     [postMessage],
   );
 
-  const handlers = useMemo<HandlerEntries>(
+  const handlers = useMemo<Handler[]>(
     () => [
-      [
-        'reaction',
-        (payload: Payload) => {
-          onReaction?.(payload.icon!);
-        },
-      ],
+      (payload: Payload) => {
+        if (
+          payload.id === 'reaction' &&
+          // Use the 'as' operator here to force the check, not sure if there is a better way to check the string value using typescript
+          reactionTypes.has(payload.reaction[1] as IconReaction)
+        ) {
+          onReaction?.(payload.reaction as IconReactionEntry);
+        }
+      },
     ],
     [onReaction],
   );

--- a/src/components/slides/use-slide-index.ts
+++ b/src/components/slides/use-slide-index.ts
@@ -1,9 +1,5 @@
 import {useCallback, useState, useMemo} from 'react';
-import {
-  type HandlerEntries,
-  type Handler,
-  type Payload,
-} from '../broadcast/use-channel-handlers';
+import {type Handler, type Payload} from '../broadcast/use-channel-handlers';
 
 export function useSlideIndex({
   postMessage,
@@ -16,7 +12,7 @@ export function useSlideIndex({
   setSlideIndex: (index: number) => void;
   navNext: () => void;
   navPrevious: () => void;
-  handlers: HandlerEntries;
+  handlers: Handler[];
   forward: boolean;
 } {
   const [slideIndex, setSlideIndex] = useState(0);
@@ -54,15 +50,14 @@ export function useSlideIndex({
     updateSlideIndexAndPost(previousSlideIndex);
   }, [updateSlideIndexAndPost, previousSlideIndex]);
 
-  const handlers = useMemo<HandlerEntries>(
+  const handlers = useMemo<Handler[]>(
     () => [
-      [
-        'slide index',
-        (payload: Payload) => {
-          setForward(payload.index! >= slideIndex);
+      (payload: Payload) => {
+        if (payload.id === 'slide index') {
+          setForward(payload.index >= slideIndex);
           updateSlideIndex(payload.index);
-        },
-      ],
+        }
+      },
     ],
     [updateSlideIndex, slideIndex],
   );

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -95,7 +95,6 @@ export default function Toolbar({
             window.location.search
           }`}
           onClick={(event) => {
-            console.log('hello');
             event.preventDefault();
             window.open(
               `${window.location.origin}/s/${presentation?.id ?? ''}${
@@ -154,7 +153,6 @@ export default function Toolbar({
           label={isFullscreen ? 'window' : 'fullscreen'}
           title="Toggle fullscreen"
           onClick={() => {
-            console.log('go fullscreen');
             if (!document.fullscreenElement) {
               void document.documentElement.requestFullscreen();
             } else if (document.exitFullscreen) {

--- a/src/pages/Audience.Test.tsx
+++ b/src/pages/Audience.Test.tsx
@@ -15,16 +15,6 @@ beforeAll(async () => {
     {method: 'DELETE'},
   );
 
-  await fetch(
-    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/test',
-    {method: 'DELETE'},
-  );
-
-  await fetch(
-    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/test/reactions',
-    {method: 'DELETE'},
-  );
-
   // Add a single presentation to firestore
   await setDoc(doc(firestore, 'presentations', 'presentation-2'), {
     uid: cred.user.uid,
@@ -35,6 +25,18 @@ beforeAll(async () => {
     title: 'test presentation',
     twitterHandle: '@doesnotexist',
   } satisfies PresentationCreate);
+});
+
+beforeEach(async () => {
+  await fetch(
+    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/test',
+    {method: 'DELETE'},
+  );
+
+  await fetch(
+    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/test/reactions',
+    {method: 'DELETE'},
+  );
 });
 
 describe('Audience view', () => {

--- a/src/pages/Audience.tsx
+++ b/src/pages/Audience.tsx
@@ -39,7 +39,6 @@ export default function Audience() {
     onIncoming: handleIncomingBroadcast,
   });
 
-  // Console.log({connectedSupabase});
   // Track the slide index from the broadcast channel
   const {
     slideIndex,
@@ -90,9 +89,9 @@ export default function Audience() {
           // SetFire({});
           postConfetti();
         }}
-        handleReaction={(icon) => {
+        handleReaction={(reaction) => {
           // AddReaction(icon);
-          postReaction(icon);
+          postReaction(reaction);
         }}
       />
       <Shares presentation={presentation} slideIndex={slideIndex} />

--- a/src/pages/Audience.tsx
+++ b/src/pages/Audience.tsx
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useCallback} from 'react';
 import {Link} from 'react-router-dom';
 import useConfetti from '../components/confetti/use-confetti';
 import {useSlideIndex} from '../components/slides/use-slide-index';
@@ -18,6 +18,7 @@ import Slideshow from '../components/slides/Slideshow';
 import usePresentation from '../components/slides/use-presentation';
 import Shares from '../components/Shares';
 import useBroadcastFirebase from '../components/broadcast/use-broadcast-firestore';
+import useClearReactions from '../components/reactions/use-clear-reactions';
 
 export default function Audience() {
   // Const {presentationId} = useParams();
@@ -51,17 +52,31 @@ export default function Audience() {
   useSearchParametersSlideIndex(setSlideIndex, slideIndex);
 
   // Configure the confetti to use the broadcast channel
-  const [fire, setFire] = useState<boolean | Record<string, unknown>>(false);
-  const {postConfetti, handlers: confettiHandlers} = useConfetti({
+  // const [fire, setFire] = useState<boolean | Record<string, unknown>>(false);
+  const [reset, setReset] = useState<boolean | Record<string, unknown>>(false);
+  const clearConfetti = useCallback(() => {
+    setReset({});
+  }, [setReset]);
+
+  const {
+    postConfetti,
+    handlers: confettiHandlers,
+    confettiReactions,
+  } = useConfetti({
     postMessage: postBroadcastMessage,
-    onConfetti: setFire,
   });
 
   // Configure reaction broadcasting
-  const {reactions, removeReaction, addReaction} = useReactions();
+  const {reactions, removeReaction, addReactions, clearReactions} =
+    useReactions();
   const {postReaction, handlers: handlersReactions} = useRemoteReactions({
     postMessage: postBroadcastMessage,
-    onReaction: addReaction,
+    onReactions: addReactions,
+  });
+
+  const {handlers: clearHandlers} = useClearReactions({
+    setClearConfetti: clearConfetti,
+    setClearIcons: clearReactions,
   });
 
   // Combine all of the incoming message handlers
@@ -70,6 +85,7 @@ export default function Audience() {
     confettiHandlers,
     slideIndexHandlers,
     handlersReactions,
+    clearHandlers,
   );
 
   return (
@@ -82,7 +98,8 @@ export default function Audience() {
         />
       </div>
 
-      <Confetti fire={fire} />
+      <Confetti confettiReactions={confettiReactions} clear={reset} />
+
       <Reactions reactions={reactions} removeReaction={removeReaction} />
       <ReactionControls
         handleConfetti={() => {

--- a/src/pages/Speaker.Test.tsx
+++ b/src/pages/Speaker.Test.tsx
@@ -21,16 +21,6 @@ beforeAll(async () => {
     {method: 'DELETE'},
   );
 
-  await fetch(
-    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/speakertest',
-    {method: 'DELETE'},
-  );
-
-  await fetch(
-    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/speakertest/reactions',
-    {method: 'DELETE'},
-  );
-
   // Add a single presentation to firestore
   await setDoc(doc(firestore, 'presentations', 'speakertest'), {
     uid: cred.user.uid,
@@ -41,6 +31,18 @@ beforeAll(async () => {
     title: 'test presentation',
     twitterHandle: '@doesnotexist',
   } satisfies PresentationCreate);
+});
+
+beforeEach(async () => {
+  await fetch(
+    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/speakertest',
+    {method: 'DELETE'},
+  );
+
+  await fetch(
+    'http://127.0.0.1:8080/emulator/v1/projects/demo-test/databases/(default)/documents/sessions/speakertest/reactions',
+    {method: 'DELETE'},
+  );
 });
 
 describe('Speaker view', () => {

--- a/src/pages/Speaker.Test.tsx
+++ b/src/pages/Speaker.Test.tsx
@@ -177,6 +177,9 @@ describe('Speaker view', () => {
       name: 'love',
     });
 
+    // Depending on the performance of the machine running the test
+    // the removal can happen super fast. Start waiting for it now,
+    // before removing. This makes the test more stable.
     const removalPromise = waitForElementToBeRemoved(() =>
       queryByRole(presentation, 'figure', {name: 'love'}),
     );

--- a/src/pages/Speaker.Test.tsx
+++ b/src/pages/Speaker.Test.tsx
@@ -8,6 +8,7 @@ import {
   render,
   findByRole,
   queryByRole,
+  waitForElementToBeRemoved,
 } from '../test/test-utils';
 import Routes from '../Routes';
 import {type PresentationCreate} from '../../functions/src/presentation';
@@ -176,9 +177,13 @@ describe('Speaker view', () => {
       name: 'love',
     });
 
+    const removalPromise = waitForElementToBeRemoved(() =>
+      queryByRole(presentation, 'figure', {name: 'love'}),
+    );
+
     const clear = await findByRole(speaker, 'button', {name: 'clear'});
     await userEvent.click(clear);
 
-    expect(queryByRole(presentation, 'figure', {name: 'love'})).toBeNull();
+    await removalPromise;
   });
 });

--- a/src/pages/Speaker.tsx
+++ b/src/pages/Speaker.tsx
@@ -22,6 +22,7 @@ import Slideshow from '../components/slides/Slideshow';
 import NavButtons from '../components/toolbar/NavButtons';
 import Button from '../components/toolbar/Button';
 import useBroadcastFirebase from '../components/broadcast/use-broadcast-firestore';
+import useClearReactions from '../components/reactions/use-clear-reactions';
 
 const textSizes = [
   'text-xs',
@@ -74,10 +75,6 @@ export default function Speaker() {
   );
   useSearchParametersSlideIndex(setSlideIndex, slideIndex);
 
-  // We fire and reset confetti on the broadcast channel (ignoring incoming confetti)
-  const {postConfettiReset: postConfettiResetBroadcastChannel} = useConfetti({
-    postMessage: postBroadcastChannel,
-  });
   const {postMessage: postBroadcastSupabase} = useBroadcastFirebase({
     sessionId,
   });
@@ -88,6 +85,18 @@ export default function Speaker() {
   const {postReaction} = useRemoteReactions({
     postMessage: postBroadcastSupabase,
   });
+
+  const {clearReactions: clearBroadcastChannel} = useClearReactions({
+    postMessage: postBroadcastChannel,
+  });
+  const {clearReactions: clearFirebase} = useClearReactions({
+    postMessage: postBroadcastSupabase,
+  });
+
+  const clear = useCallback(() => {
+    clearBroadcastChannel();
+    clearFirebase();
+  }, [clearBroadcastChannel, clearFirebase]);
 
   // Swipe and key bindings
   const swipeHandlers = useSwipeable({
@@ -200,7 +209,7 @@ export default function Speaker() {
               label="clear"
               title="Clear reactions"
               onClick={() => {
-                postConfettiResetBroadcastChannel();
+                clear();
               }}
             />
           </div>


### PR DESCRIPTION
Big refactor to key incoming reactions and track all reactions during a session. This should limit the impact of spotty connections when the snapshot listener disconnects and reconnects, causing all reactions to be re-read from the db.